### PR TITLE
Config version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.gem
 .bundle
+.rvmrc
 Gemfile.lock
 pkg/*

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ You'll want to be able to pause the scenario at some point to inspect things
 in Firebug. A step definition for `Then stop and let me debug` is provided
 for this purpose. When executed, it breaks in the Ruby debugger.
 
+## Using Firefox 4 and Firebug 1.7.0
+
+If you want to use Firefox 4 with Firebug 1.7.0, configure the firebug_version
+setting in your `capybara.rb` support file
+
+    # located in features/support/capybara.rb or similar
+    require 'capybara/firebug'
+    Selenium::WebDriver::Firefox::Profile.firebug_version = '1.7.0'
+
 ## Customizing the Profile
 
 If you wish to further customize the Firefox profile used by selenium, you

--- a/lib/capybara/firebug.rb
+++ b/lib/capybara/firebug.rb
@@ -1,7 +1,16 @@
 require 'selenium/webdriver'
 
 class Selenium::WebDriver::Firefox::Profile
-  def enable_firebug(version = "1.6.2")
+  def self.firebug_version
+    @firebug_version ||= '1.6.2'
+  end
+
+  def self.firebug_version=(version)
+    @firebug_version = version
+  end
+
+  def enable_firebug(version = nil)
+    version ||= Selenium::WebDriver::Firefox::Profile.firebug_version
     add_extension(File.expand_path("../firebug-#{version}.xpi", __FILE__))
 
     # Prevent "Welcome!" tab

--- a/spec/enable_firebug_spec.rb
+++ b/spec/enable_firebug_spec.rb
@@ -1,13 +1,15 @@
 require 'spec_helper'
 
-describe Selenium::WebDriver::Firefox::Profile, "#enable_firebug" do
-  it "adds the Firebug extension" do
-    subject.should_receive(:add_extension).with(/firebug-1\.6\.2\.xpi$/)
-    subject.enable_firebug
-  end
+describe Selenium::WebDriver::Firefox::Profile do
+  describe "#enable_firebug" do
+    it "adds the Firebug extension" do
+      subject.should_receive(:add_extension).with(/firebug-1\.6\.2\.xpi$/)
+      subject.enable_firebug
+    end
 
-  it "accepts an optional version argument" do
-    subject.should_receive(:add_extension).with(/firebug-1\.7\.0\.xpi$/)
-    subject.enable_firebug("1.7.0")
+    it "accepts an optional version argument" do
+      subject.should_receive(:add_extension).with(/firebug-1\.7\.0\.xpi$/)
+      subject.enable_firebug("1.7.0")
+    end
   end
 end

--- a/spec/enable_firebug_spec.rb
+++ b/spec/enable_firebug_spec.rb
@@ -1,9 +1,33 @@
 require 'spec_helper'
 
 describe Selenium::WebDriver::Firefox::Profile do
+  describe ".firebug_version" do
+    subject { described_class.firebug_version }
+
+    it "defaults to 1.6.2" do
+      should == "1.6.2"
+    end
+
+    context "when set" do
+      before { described_class.firebug_version = requested_version }
+
+      let(:requested_version) { '1.7.0' }
+
+      it { should == requested_version }
+    end
+  end
+
   describe "#enable_firebug" do
+    before { Selenium::WebDriver::Firefox::Profile.firebug_version = nil }
+
     it "adds the Firebug extension" do
       subject.should_receive(:add_extension).with(/firebug-1\.6\.2\.xpi$/)
+      subject.enable_firebug
+    end
+
+    it "honors the configured version" do
+      Selenium::WebDriver::Firefox::Profile.firebug_version = '1.7.0'
+      subject.should_receive(:add_extension).with(/firebug-1\.7\.0\.xpi$/)
       subject.enable_firebug
     end
 


### PR DESCRIPTION
Hi,

I added a simple configuration option to make it dead simple to switch firefox versions. The argument to enable_firebug is still honored, but the default can now be configured in one line in your support files.
