### PR TITLE
Update for capybara 1.0.0

### DIFF
--- a/capybara-firebug.gemspec
+++ b/capybara-firebug.gemspec
@@ -20,7 +20,7 @@ enabled under the selenium driver.}
 
   # We rely on this 0.4.1.2 bug fix:
   # https://github.com/jnicklas/capybara/commit/90a1cf78ab782a5cb596a8c3d8611e465d591cd1
-  s.add_dependency "capybara", "~> 0.4.1.2"
+  s.add_dependency "capybara", ">= 0.4.1.2"
 
   s.add_development_dependency "rspec", "~> 2.0"
   s.add_development_dependency "cucumber", "~> 0.10.0"

--- a/capybara-firebug.gemspec
+++ b/capybara-firebug.gemspec
@@ -20,7 +20,7 @@ enabled under the selenium driver.}
 
   # We rely on this 0.4.1.2 bug fix:
   # https://github.com/jnicklas/capybara/commit/90a1cf78ab782a5cb596a8c3d8611e465d591cd1
-  s.add_dependency "capybara", ">= 0.4.1.2"
+  s.add_dependency "capybara", "~> 1.0"
 
   s.add_development_dependency "rspec", "~> 2.0"
   s.add_development_dependency "cucumber", "~> 0.10.0"

--- a/lib/capybara/firebug.rb
+++ b/lib/capybara/firebug.rb
@@ -32,7 +32,7 @@ end
 Capybara.register_driver :selenium_with_firebug do |app|
   profile = Selenium::WebDriver::Firefox::Profile.new
   profile.enable_firebug
-  Capybara::Driver::Selenium.new(app, :browser => :firefox, :profile => profile)
+  Capybara::Selenium::Driver.new(app, :browser => :firefox, :profile => profile)
 end
 
 if defined?(Cucumber::RbSupport)


### PR DESCRIPTION
This patch makes capybara-firebug compatible with capybara 1.0.0.
